### PR TITLE
Allow Command Line Arguments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
 
     entry_points={'console_scripts': [
         'EclipsingBinaries = EclipsingBinaries.menu:main'
+        'EB_pipeline=EclipsingBinaries.pipeline:monitor_directory'
     ],
     },
 


### PR DESCRIPTION
Allows for command line arguments to be added if entered into the command line "EB_pipeline"