### PR TITLE
Removing Conda Install Option

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -29,13 +29,6 @@ To install ccdproc with `pip <https://pip.pypa.io/en/latest/>`_, simply run::
 
     pip install EclipsingBinaries
 
-Using conda
--------------
-
-To install ccdproc with `anaconda`_, run::
-
-    conda install -c conda-forge ccdproc
-
 Updating
 --------
 


### PR DESCRIPTION
Removing anaconda install option as that does not seem to work at the moment. Might add at a later date.