### PR TITLE
Fixed Warning

### DIFF
--- a/docs/EB.rst
+++ b/docs/EB.rst
@@ -1,7 +1,7 @@
 .. _EB:
 
 Running EclipsingBinaries
-===============
+=========================
 
 Script
 ------


### PR DESCRIPTION
Fixed underline not long enough warning in readthedocs