### PR TITLE
Exclude .fits files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,4 @@ include LICENSE
 include README.md
 include pyproject.toml
 
-global-exclude *.fts
+global-exclude *.fts *.fits


### PR DESCRIPTION
Want to exclude both `.fts` and `.fits` files from being built with the distribution.