### PR TITLE
Switching from Image to OS

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,7 +2,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  image: latest
+  os: "ubuntu-22.04" # can no longer use build.image but must be build.os
 
 python:
   version: 3.8


### PR DESCRIPTION
ReadTheDocs moved over to build.os instead of build.image on October 16,2023