### PR TITLE
Python Version to Build.tools

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,11 +1,12 @@
 version: 2
-
+# see this website for other commands https://docs.readthedocs.io/en/stable/config-file/v2.html
 # Set the version of Python and other tools you might need
 build:
   os: "ubuntu-22.04" # can no longer use build.image but must be build.os
+  tools:
+    python: "3.8"
 
 python:
-  version: 3.8
   install:
     - requirements: requirements.txt
     - method: pip


### PR DESCRIPTION
Moving the required python version from under the python label to build.tools