### PR TITLE
Allows for standard version printing

### DIFF
--- a/EclipsingBinaries/__init__.py
+++ b/EclipsingBinaries/__init__.py
@@ -1,1 +1,3 @@
-__version__ = "4.1.4"
+# Version
+from .version import __version__
+__version__ = version.__version__

--- a/EclipsingBinaries/version.py
+++ b/EclipsingBinaries/version.py
@@ -1,0 +1,2 @@
+# Version
+__version__ = "4.1.4"


### PR DESCRIPTION
This allows the package to be able to use the standard print(__version__) like most packages.