### PR TITLE
Potential Crashing

### DIFF
--- a/EclipsingBinaries/tess_data_search.py
+++ b/EclipsingBinaries/tess_data_search.py
@@ -34,6 +34,7 @@ def main():
             break
         except astroquery.exceptions.ResolverError:
             print("\nThe TIC number you entered is invalid or there is no data for this given system.\n")
+            main() # Incase the user mistyped the number have them re-enter the TIC number or allow them to close the program
 
     if system_name.lower() == "close":
         exit()


### PR DESCRIPTION
This removes a potential crash in the program if the user enters a wrong TIC number. The program would continue through with no data available which results in a crash at some point.