### PR TITLE
Missing Sphinx Required Key

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,3 +13,7 @@ python:
       path: .
       extra_requirements:
         - docs
+
+# This is the REQUIRED key mentioned in the error
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
Readthedocs requires this new Sphinx key in order to build the documentation.