### PR TITLE
Fix SyntaxWarnings from invalid escape sequences in LaTeX strings

### DIFF
--- a/EclipsingBinaries/OConnell.py
+++ b/EclipsingBinaries/OConnell.py
@@ -441,29 +441,29 @@ def multi_OConnell_total(filter_files, Epoch, period, order=10,
         table_header += '}\n' + '\\hline\\hline\n' + 'Parameter '
         for band in range(filters):
             table_header += '& Filter ' + str(band + 1)
-        table_header += '\\\ \n' + '\\hline\n'
+        table_header += r'\\ ' + '\n' + '\\hline\n'
 
         a1_line = '$a_1$ '
         a2_line = '$a_2$ '
         a4_line = '$a_4$ '
         a22_line = '$a_2(0.125-a_2)$ '
         b1_line = '$2b_1$ '
-        dIFT_line = '$\Delta I_{\\rm FT}$ '
-        dIave_line = '$\Delta I_{\\rm ave}$ '
+        dIFT_line = r'$\Delta I_{\rm FT}$ '
+        dIave_line = r'$\Delta I_{\rm ave}$ '
         OER_line = 'OER '
         LCA_line = 'LCA '
 
         strr = lambda x, e=5: str(round(x, e))
         for band in range(filters):
-            a1_line += '& $' + strr(a_all[band][1]) + '\pm ' + strr(a_err_all[band][1]) + '$ '
-            a2_line += '& $' + strr(a_all[band][2]) + '\pm ' + strr(a_err_all[band][2]) + '$ '
-            a4_line += '& $' + strr(a_all[band][4]) + '\pm ' + strr(a_err_all[band][4]) + '$ '
-            a22_line += '& $' + strr(a22s[band]) + '\pm ' + strr(a22s_err[band]) + '$ '
-            b1_line += '& $' + strr(2 * b_all[band][1]) + '\pm ' + strr(2 * b_err_all[band][1]) + '$ '
-            dIFT_line += '& $' + strr(dI_FT[band]) + '\pm ' + strr(dI_FT_err[band]) + '$ '
-            dIave_line += '& $' + strr(dI_ave[band]) + '\pm ' + strr(dI_ave_err[band]) + '$ '
-            OER_line += '& $' + strr(OERs[band]) + '\pm ' + strr(OERs_err[band]) + '$ '
-            LCA_line += '& $' + strr(LCAs[band]) + '\pm ' + strr(LCAs_err[band]) + '$ '
+            a1_line += '& $' + strr(a_all[band][1]) + r'\pm ' + strr(a_err_all[band][1]) + '$ '
+            a2_line += '& $' + strr(a_all[band][2]) + r'\pm ' + strr(a_err_all[band][2]) + '$ '
+            a4_line += '& $' + strr(a_all[band][4]) + r'\pm ' + strr(a_err_all[band][4]) + '$ '
+            a22_line += '& $' + strr(a22s[band]) + r'\pm ' + strr(a22s_err[band]) + '$ '
+            b1_line += '& $' + strr(2 * b_all[band][1]) + r'\pm ' + strr(2 * b_err_all[band][1]) + '$ '
+            dIFT_line += '& $' + strr(dI_FT[band]) + r'\pm ' + strr(dI_FT_err[band]) + '$ '
+            dIave_line += '& $' + strr(dI_ave[band]) + r'\pm ' + strr(dI_ave_err[band]) + '$ '
+            OER_line += '& $' + strr(OERs[band]) + r'\pm ' + strr(OERs_err[band]) + '$ '
+            LCA_line += '& $' + strr(LCAs[band]) + r'\pm ' + strr(LCAs_err[band]) + '$ '
 
         if cancel_event.is_set():
             log("Task canceled.")
@@ -471,7 +471,7 @@ def multi_OConnell_total(filter_files, Epoch, period, order=10,
 
         lines = [a1_line, a2_line, a4_line, a22_line, b1_line, dIFT_line, dIave_line, OER_line, LCA_line]
         for count, _ in enumerate(lines):
-            lines[count] += '\\\ \n'
+            lines[count] += r'\\ ' + '\n'
 
         output = table_header
         for _, line in enumerate(lines):

--- a/EclipsingBinaries/color_light_curve.py
+++ b/EclipsingBinaries/color_light_curve.py
@@ -233,7 +233,7 @@ def color_plot(Bfile, Vfile, Epoch, period, max_tol=0.03, lower_lim=0.05, Rfile=
         mag.text(ytickpad, (max(Bmag) + min(Bmag)) / 2, 'B', rotation=90, fontsize=fs * 1.2)
         mag.text(ytickpad, (max(Vmag) + min(Vmag)) / 2, 'V', rotation=90, fontsize=fs * 1.2)
         # bv.set_xlabel('$\Phi$',fontsize=fs*1.2)
-        bv.set_xlabel('$\Phi$', fontsize=fs * 1.5, usetex=False)
+        bv.set_xlabel(r'$\Phi$', fontsize=fs * 1.5, usetex=False)
         bv.set_ylabel(r'$\rm B-V$', fontsize=fs * 1.2)
         # quadcolor,colorerr=B_V[3:5:]
         bv.axhline(quadcolor, color='gray', linewidth=None)
@@ -519,7 +519,7 @@ def color_gui(developer=False):
             mag.text(ytickpad, (max(Bmag) + min(Bmag)) / 2, 'B', rotation=90, fontsize=fs * 1.2)
             mag.text(ytickpad, (max(Vmag) + min(Vmag)) / 2, 'V', rotation=90, fontsize=fs * 1.2)
             # bv.set_xlabel('$\Phi$',fontsize=fs*1.2)
-            bv.set_xlabel('$\Phi$', fontsize=fs * 1.2, usetex=False)
+            bv.set_xlabel(r'$\Phi$', fontsize=fs * 1.2, usetex=False)
             bv.set_ylabel(r'$\rm B-V$', fontsize=fs * 1.2)
             # quadcolor,colorerr=B_V[3:5:]
             # bv.axhline(quadcolor,color='gray',linewidth=None)
@@ -586,11 +586,11 @@ def color_gui(developer=False):
                 # vr.plot([''])
                 # vr.annotate(r'$V-R_{\rm C}='+str(round(VRc,4))+'\pm'+str(round(VRerr,4))+'$',xy=(0.25,VRc),ha='center',va='center',bbox=dict(facecolor='white', edgecolor='gray',boxstyle='round',pad=0.1),fontsize=11)
 
-                vr.annotate(r'$V-R_{\rm C}=' + str(round(VRc, 4)) + '\pm' + str(round(VRerr, 4)) + '$',
+                vr.annotate(r'$V-R_{\rm C}=' + str(round(VRc, 4)) + r'\pm' + str(round(VRerr, 4)) + '$',
                             xytext=(0.25, vr.get_ylim()[-1]), xy=(0, VRc), ha='center', va='center',
                             bbox=dict(facecolor='white', edgecolor='gray', pad=0.1), fontsize=11,
                             arrowprops=dict(arrowstyle='-', color='gray', linewidth=1.5))
-                bv.annotate(r'$B-V=' + str(round(quadcolor, 4)) + '\pm' + str(round(colorerr, 4)) + '$',
+                bv.annotate(r'$B-V=' + str(round(quadcolor, 4)) + r'\pm' + str(round(colorerr, 4)) + '$',
                             xytext=(0.25, bv.get_ylim()[-1]), xy=(0, quadcolor), ha='center', va='center',
                             bbox=dict(facecolor='white', edgecolor='gray', linewidth=1.5), fontsize=11,
                             arrowprops=dict(arrowstyle='-', color='gray', linewidth=1.5))


### PR DESCRIPTION
Closes #448

Prefix affected strings with `r` (raw string) to suppress `SyntaxWarning`
raised by Python 3.12 for invalid escape sequences (`\p`, `\D`, `\ `) in
`OConnell.py` and `color_light_curve.py`. These will become `SyntaxErrors`
in a future Python version.

## Changes
- `OConnell.py`: lines 444, 451, 452, 458–466, 474
- `color_light_curve.py`: lines 236, 522, 589, 593

## Testing
Launched the GUI — no warnings on the console and app behaves normally.