### PR TITLE
Fix overlay IsADirectoryError and cross-platform path separators

### DIFF
--- a/EclipsingBinaries/apass.py
+++ b/EclipsingBinaries/apass.py
@@ -9,6 +9,7 @@ Last Updated: 03/11/2026
 from astroquery.vizier import Vizier
 import numpy as np
 import pandas as pd
+import os
 
 import astropy.units as u
 import astropy.coordinates as coord
@@ -175,7 +176,7 @@ def cousins_r(ra, dec, pipeline, folder_path, obj_name, write_callback, cancel_e
             "e_TMag": T_err_list
         })
 
-        output_file = folder_path + "\\APASS_" + obj_name + "_Rc.txt"
+        output_file = os.path.join(folder_path, "APASS_" + obj_name + "_Rc.txt")
         # noinspection PyTypeChecker
         final.to_csv(output_file, index=True, sep="\t")
         log("Completed Cousins R calculations.")
@@ -349,7 +350,7 @@ def catalog_finder(ra, dec, pipeline, folder_path, obj_name, write_callback, can
         log("Processing data from the Vizier catalog.")
         df = process_data(result)
 
-        text_file = folder_path + "\\APASS_" + obj_name + "_catalog.txt"
+        text_file = os.path.join(folder_path, "APASS_" + obj_name + "_catalog.txt")
 
         save_to_file(df, text_file)
 
@@ -464,7 +465,7 @@ def create_radec(df, ra, dec, T_list, pipeline, folder_path, obj_name, write_cal
             lines = create_lines(ra_list, dec_list, mag_list, ra, dec, filt)
 
             output = header + lines
-            outputfile = folder_path + "\\" + obj_name + "_" + filt
+            outputfile = os.path.join(folder_path, obj_name + "_" + filt)
 
             with open(outputfile + ".radec", "w") as file:
                 file.write(output)
@@ -492,6 +493,15 @@ def overlay(df, tar_ra, tar_dec, fits_file):
     # NSVS_254037-S001-R004-C001-Empty-R-B2.fts
     # fits_file = input("Enter file pathway to one of your science image files for creating an overlay or "
     #                   "comparison stars: ")
+
+    # If a directory is given, find the first FITS file within it
+    if os.path.isdir(fits_file):
+        fits_extensions = ('.fits', '.fts', '.fit', '.FITS', '.FTS', '.FIT')
+        candidates = sorted(f for f in os.listdir(fits_file) if f.endswith(fits_extensions))
+        if not candidates:
+            print(f"No FITS files found in {fits_file}. Skipping overlay.")
+            return
+        fits_file = os.path.join(fits_file, candidates[0])
 
     # get the image data for plotting purposes
     header_data_unit_list = fits.open(fits_file)

--- a/EclipsingBinaries/menu.py
+++ b/EclipsingBinaries/menu.py
@@ -751,11 +751,11 @@ class ProgramLauncher(TkinterDnD.Tk):
                                            validation_func=lambda x: len(x.strip()) > 0,
                                            error_message="Please enter the object name.")
 
-        science_image = self.create_input_field(self.right_frame, "Science Image Folder Path:",
+        science_image = self.create_input_field(self.right_frame, "Science Image File:",
                                                 r"C:\folder1\calibrated_images", row=5,
                                                 validation_func=lambda x: len(x.strip()) > 0,
                                                 error_message="Please enter a file pathway.",
-                                                browse_type="folder")
+                                                browse_type="file")
 
         # Buttons for comparison selector
         Button(self.right_frame, text="Run Comparison Selector", font=self.button_font, bg="#003366", fg="white",


### PR DESCRIPTION
Closes #450

## Changes

- `overlay()` now detects when a directory is passed for the science
  image path and selects the first FITS file found within it, rather
  than attempting to open the directory itself as a FITS file
- Replaced Windows-style `"\\"` path concatenation with `os.path.join()`
  on lines 178, 352, and 467 for cross-platform compatibility

## Testing
Tested successfully on both macOS and Windows.