### PR TITLE
Use TIC v8.2 for Tmag/e_Tmag in APASS workflow with robust matching, precision fixes, and RADEC formatting cleanup

### DIFF
--- a/EclipsingBinaries/apass.py
+++ b/EclipsingBinaries/apass.py
@@ -3,7 +3,7 @@ Combines all APASS programs that were originally separate on GitHub for an easy 
 
 Author: Kyle Koeller
 Created: 12/26/2022
-Last Updated: 03/11/2026
+Last Updated: 04/19/2026
 """
 
 from astroquery.vizier import Vizier
@@ -24,7 +24,7 @@ import warnings
 from PyAstronomy import pyasl
 
 from .gaia import tess_mag as ga
-from .vseq_updated import isNaN, conversion, splitter, decimal_limit
+from .vseq_updated import isNaN, conversion, splitter
 
 # turn off this warning that just tells the user,
 # "The warning raised when the contents of the FITS header have been modified to be standards compliant."
@@ -65,8 +65,9 @@ def comparison_selector(ra="", dec="", pipeline=False, folder_path="", obj_name=
             return
 
         log("Starting the process for finding APASS stars.")
-        apass_file, input_ra, input_dec, T_list = cousins_r(ra, dec, pipeline, folder_path, obj_name, write_callback,
-                                                            cancel_event)
+        apass_file, input_ra, input_dec, input_ra_text, input_dec_text, T_list = cousins_r(
+            ra, dec, pipeline, folder_path, obj_name, write_callback, cancel_event
+        )
         df = pd.read_csv(apass_file, header=None, skiprows=[0], sep="\t")
 
         log("Finished Saving")
@@ -74,8 +75,19 @@ def comparison_selector(ra="", dec="", pipeline=False, folder_path="", obj_name=
         #     "The output file you have entered has RA and DEC for stars and their B, V, Cousins R, and TESS T magnitudes "
         #     "with their respective errors.\n")
 
-        radec_list = create_radec(df, input_ra, input_dec, T_list, pipeline, folder_path, obj_name, write_callback,
-                                  cancel_event)
+        radec_list = create_radec(
+            df,
+            input_ra,
+            input_dec,
+            T_list,
+            pipeline,
+            folder_path,
+            obj_name,
+            write_callback,
+            cancel_event,
+            target_ra_text=input_ra_text,
+            target_dec_text=input_dec_text
+        )
 
         overlay(df, input_ra, input_dec, science_image)
 
@@ -121,8 +133,9 @@ def cousins_r(ra, dec, pipeline, folder_path, obj_name, write_callback, cancel_e
         e_beta = 0.03
         gamma = 0.219
 
-        input_file, input_ra, input_dec = catalog_finder(ra, dec, pipeline, folder_path, obj_name, write_callback,
-                                                         cancel_event)
+        input_file, input_ra, input_dec, input_ra_text, input_dec_text = catalog_finder(
+            ra, dec, pipeline, folder_path, obj_name, write_callback, cancel_event
+        )
         df = pd.read_csv(input_file, header=None, skiprows=[0], sep=",")
 
         # writes the columns from the input file
@@ -159,7 +172,9 @@ def cousins_r(ra, dec, pipeline, folder_path, obj_name, write_callback, cancel_e
         ra_decimal = np.array(splitter(ra))
         dec_decimal = np.array(splitter(dec))
         log("Starting Gaia Search for TESS Magnitudes\n")
-        T_list, T_err_list = ga(ra_decimal, dec_decimal, write_callback, cancel_event)
+        log("The 'T' filter is from the TESS Input Catalog (TIC v8.2). Please go to the GitHub "
+            "page for more information.\n")
+        T_list, T_err_list = ga(ra_decimal, dec_decimal, write_callback, cancel_event, apass_vmag=V)
 
         # puts all columns into a dataframe for output
         final = pd.DataFrame({
@@ -181,7 +196,7 @@ def cousins_r(ra, dec, pipeline, folder_path, obj_name, write_callback, cancel_e
         final.to_csv(output_file, index=True, sep="\t")
         log("Completed Cousins R calculations.")
 
-        return output_file, input_ra, input_dec, T_list
+        return output_file, input_ra, input_dec, input_ra_text, input_dec_text, T_list
     except Exception as e:
         log(f"An error occurred: {e}")
         raise
@@ -278,14 +293,14 @@ def process_data(vizier_result):
     # converts all list values to numbers and RA/Dec coordinates and magnitudes to numbers with limited decimal places
     ra_final = conversion(ra_new)
     dec_new = conversion(dec)
-    bmag_new = decimal_limit(bmag)
-    e_bmag_new = decimal_limit(e_bmag)
-    vmag_new = decimal_limit(vmag)
-    e_vmag_new = decimal_limit(e_vmag)
-    gmag_new = decimal_limit(gmag)
-    e_gmag_new = decimal_limit(e_gmag)
-    rmag_new = decimal_limit(rmag)
-    e_rmag_new = decimal_limit(e_rmag)
+    bmag_new = _format_decimal_list(bmag, 3)
+    e_bmag_new = _format_decimal_list(e_bmag, 3)
+    vmag_new = _format_decimal_list(vmag, 3)
+    e_vmag_new = _format_decimal_list(e_vmag, 3)
+    gmag_new = _format_decimal_list(gmag, 3)
+    e_gmag_new = _format_decimal_list(e_gmag, 3)
+    rmag_new = _format_decimal_list(rmag, 3)
+    e_rmag_new = _format_decimal_list(e_rmag, 3)
 
     # places all lists into a DataFrame to paste into a text file for comparison star finder
     df = pd.DataFrame({
@@ -302,6 +317,24 @@ def process_data(vizier_result):
     })
 
     return df
+
+
+def _format_decimal_list(values, places):
+    """
+    Formats numeric values as strings with a fixed number of decimal places.
+
+    :param values: Sequence of numeric values
+    :param places: Number of decimal places to preserve
+    :return: List of formatted numeric strings
+    """
+    formatted_values = []
+    for value in values:
+        try:
+            numeric_value = float(value)
+            formatted_values.append(format(numeric_value, f".{places}f"))
+        except (TypeError, ValueError):
+            formatted_values.append("nan")
+    return formatted_values
 
 
 def save_to_file(df, filepath):
@@ -355,7 +388,7 @@ def catalog_finder(ra, dec, pipeline, folder_path, obj_name, write_callback, can
         save_to_file(df, text_file)
 
         log("Finished cataloging the Vizier results.")
-        return text_file, ra_input[0], dec_input[0]
+        return text_file, ra_input[0], dec_input[0], ra, dec
     except Exception as e:
         log(f"An error occurred: {e}")
         raise
@@ -377,9 +410,44 @@ def create_header(ra, dec):
              "#Apparent Magnitude or missing (value = apparent magnitude, or value > 99 or missing = no mag info)\n" \
              "#Add one comma separated line per aperture in the following format:\n"
     header += "#RA, Dec, Ref Star, Centroid, Magnitude\n"
-    header += str(conversion([ra])[0]) + ", " + str(conversion([dec])[0]) + ", 0, 1, 99.999\n"
+    header += f"{_format_target_coord(ra)}, {_format_target_coord(dec)}, 0, 1, 99.999\n"
 
     return header
+
+
+# --- _format_target_coord ---
+# Formats target coordinates while preserving input sexagesimal precision.
+def _format_target_coord(value):
+    """
+    Formats a target coordinate value for RADEC header output.
+
+    :param value: Coordinate value in sexagesimal string or decimal format
+    :return: Formatted coordinate string
+    """
+    if isinstance(value, str) and ":" in value:
+        return value.strip()
+    return str(conversion([value])[0])
+
+
+def _format_radec_magnitude(value):
+    """
+    Formats magnitude values for RADEC file output with consistent precision.
+
+    :param value: Magnitude value
+    :return: Formatted magnitude string
+    """
+    if isNaN(value):
+        return "99.999"
+
+    try:
+        numeric_value = float(value)
+    except (TypeError, ValueError):
+        return "99.999"
+
+    if numeric_value >= 99:
+        return "99.999"
+
+    return format(numeric_value, ".3f")
 
 
 def create_lines(ra_list, dec_list, mag_list, ra, dec, filt):
@@ -407,12 +475,25 @@ def create_lines(ra_list, dec_list, mag_list, ra, dec, filt):
         # duplication
         angle = angle_dist(float(ra), float(dec), next_ra, next_dec)
         if angle:
-            lines += str(val) + ", " + str(dec_list[count]) + ", " + "1, 1, " + str(mag_list[count]) + "\n"
+            mag_text = _format_radec_magnitude(mag_list[count])
+            lines += str(val) + ", " + str(dec_list[count]) + ", " + "1, 1, " + mag_text + "\n"
 
     return lines
 
 
-def create_radec(df, ra, dec, T_list, pipeline, folder_path, obj_name, write_callback, cancel_event):
+def create_radec(
+    df,
+    ra,
+    dec,
+    T_list,
+    pipeline,
+    folder_path,
+    obj_name,
+    write_callback,
+    cancel_event,
+    target_ra_text=None,
+    target_dec_text=None
+):
     """
     Creates a RADEC file for all 3 filters (Johnson B, V, Cousins R, and T)
 
@@ -426,6 +507,8 @@ def create_radec(df, ra, dec, T_list, pipeline, folder_path, obj_name, write_cal
     :param write_callback: Function to write log messages to the GUI
     :param cancel_event:
 
+    :param target_ra_text: Optional original RA input string for header output
+    :param target_dec_text: Optional original DEC input string for header output
     :return: None but saves the RADEC files to user specified locations
     """
 
@@ -446,10 +529,9 @@ def create_radec(df, ra, dec, T_list, pipeline, folder_path, obj_name, write_cal
         ra_list = df[1]
         dec_list = df[2]
 
-        header = create_header(ra, dec)
-
-        log("The 'T' filter is the calibrated TESS magnitudes calculated from Gaia magnitudes. Please go to the GitHub "
-            "page for more information.\n")
+        header_ra = target_ra_text if target_ra_text is not None else ra
+        header_dec = target_dec_text if target_dec_text is not None else dec
+        header = create_header(header_ra, header_dec)
 
         # to write lines to the file in order create new RADEC files for each filter
         file_list = []

--- a/EclipsingBinaries/apass.py
+++ b/EclipsingBinaries/apass.py
@@ -164,9 +164,9 @@ def cousins_r(ra, dec, pipeline, folder_path, obj_name, write_callback, cancel_e
                 Rc.append(99.999)
                 e_Rc.append(99.999)
             else:
-                # if there is a value then format that value with only 2 decimal places otherwise there will be like 8
-                Rc.append(format(val, ".2f"))
-                e_Rc.append(format(root, ".2f"))
+                # if there is a value then format that value with 3 decimal places for RADEC precision consistency
+                Rc.append(format(val, ".3f"))
+                e_Rc.append(format(root, ".3f"))
             count += 1
 
         ra_decimal = np.array(splitter(ra))

--- a/EclipsingBinaries/apass.py
+++ b/EclipsingBinaries/apass.py
@@ -24,7 +24,7 @@ import warnings
 from PyAstronomy import pyasl
 
 from .gaia import tess_mag as ga
-from .vseq_updated import isNaN, conversion, splitter
+from .vseq_updated import isNaN, conversion
 
 # turn off this warning that just tells the user,
 # "The warning raised when the contents of the FITS header have been modified to be standards compliant."
@@ -169,8 +169,8 @@ def cousins_r(ra, dec, pipeline, folder_path, obj_name, write_callback, cancel_e
                 e_Rc.append(format(root, ".3f"))
             count += 1
 
-        ra_decimal = np.array(splitter(ra))
-        dec_decimal = np.array(splitter(dec))
+        ra_decimal = np.array([_to_decimal_coord(value) for value in ra], dtype=float)
+        dec_decimal = np.array([_to_decimal_coord(value) for value in dec], dtype=float)
         log("Starting VizieR Search for TESS Magnitudes")
         log("Tmag is from the TESS Input Catalog (TIC v8.2). Please go to the GitHub page for more information.")
         T_list, T_err_list = ga(ra_decimal, dec_decimal, write_callback, cancel_event, apass_vmag=V)
@@ -375,8 +375,8 @@ def catalog_finder(ra, dec, pipeline, folder_path, obj_name, write_callback, can
             log("Task canceled.")
             return
 
-        ra_input = splitter([ra])
-        dec_input = splitter([dec])
+        ra_input = [_to_decimal_coord(ra)]
+        dec_input = [_to_decimal_coord(dec)]
 
         result = query_vizier(ra_input[0], dec_input[0], write_callback, cancel_event)
         log("Processing data from the Vizier catalog.")
@@ -530,8 +530,8 @@ def create_lines(ra_list, dec_list, mag_list, ra, dec, filt):
     :return: The data lines string for the RADEC file
     """
     lines = ""
-    ra_decimal = np.array(splitter(ra_list))
-    dec_decimal = np.array(splitter(dec_list))
+    ra_decimal = np.array([_to_decimal_coord(value) for value in ra_list], dtype=float)
+    dec_decimal = np.array([_to_decimal_coord(value) for value in dec_list], dtype=float)
 
     for count, val in enumerate(ra_list):
         next_ra = float(ra_decimal[count])
@@ -664,8 +664,8 @@ def overlay(df, tar_ra, tar_dec, fits_file):
     dec_catalog = list(df[2])
 
     # convert the lists to degrees for plotting purposes
-    ra_cat_new = (np.array(splitter(ra_catalog)) * 15) * u.deg
-    dec_cat_new = np.array(splitter(dec_catalog)) * u.deg
+    ra_cat_new = (np.array([_to_decimal_coord(value) for value in ra_catalog], dtype=float) * 15) * u.deg
+    dec_cat_new = np.array([_to_decimal_coord(value) for value in dec_catalog], dtype=float) * u.deg
 
     # text for the caption below the graph
     txt = "Number represents index value given in the final output catalog file."

--- a/EclipsingBinaries/apass.py
+++ b/EclipsingBinaries/apass.py
@@ -171,9 +171,8 @@ def cousins_r(ra, dec, pipeline, folder_path, obj_name, write_callback, cancel_e
 
         ra_decimal = np.array(splitter(ra))
         dec_decimal = np.array(splitter(dec))
-        log("Starting Gaia Search for TESS Magnitudes\n")
-        log("The 'T' filter is from the TESS Input Catalog (TIC v8.2). Please go to the GitHub "
-            "page for more information.\n")
+        log("Starting VizieR Search for TESS Magnitudes")
+        log("Tmag is from the TESS Input Catalog (TIC v8.2). Please go to the GitHub page for more information.")
         T_list, T_err_list = ga(ra_decimal, dec_decimal, write_callback, cancel_event, apass_vmag=V)
 
         # puts all columns into a dataframe for output
@@ -554,7 +553,7 @@ def create_radec(
 
             file_list.append(outputfile + ".radec")
 
-        log("Finished writing RADEC files for Johnson B, Johnson V, and Cousins R, and T.\n")
+        log("Finished writing RADEC files for Johnson B, Johnson V, Cousins R, and TESS magnitudes.")
 
         return file_list
     except Exception as e:

--- a/EclipsingBinaries/apass.py
+++ b/EclipsingBinaries/apass.py
@@ -409,23 +409,90 @@ def create_header(ra, dec):
              "#Apparent Magnitude or missing (value = apparent magnitude, or value > 99 or missing = no mag info)\n" \
              "#Add one comma separated line per aperture in the following format:\n"
     header += "#RA, Dec, Ref Star, Centroid, Magnitude\n"
-    header += f"{_format_target_coord(ra)}, {_format_target_coord(dec)}, 0, 1, 99.999\n"
+    header += (
+        f"{_format_target_coord(ra, is_ra=True)}, "
+        f"{_format_target_coord(dec, is_ra=False)}, 0, 1, 99.999\n"
+    )
 
     return header
 
 
 # --- _format_target_coord ---
 # Formats target coordinates while preserving input sexagesimal precision.
-def _format_target_coord(value):
+def _format_target_coord(value, is_ra):
     """
     Formats a target coordinate value for RADEC header output.
 
     :param value: Coordinate value in sexagesimal string or decimal format
+    :param is_ra: True if coordinate is right ascension, False for declination
     :return: Formatted coordinate string
     """
-    if isinstance(value, str) and ":" in value:
-        return value.strip()
-    return str(conversion([value])[0])
+    include_plus = isinstance(value, str) and value.strip().startswith("+")
+    return _format_sexagesimal_coord(value, is_ra=is_ra, include_plus=include_plus)
+
+
+# --- _format_sexagesimal_coord ---
+# Formats coordinates as HH:MM:SS.sss or +/-DD:MM:SS.sss.
+def _format_sexagesimal_coord(value, is_ra, include_plus=False):
+    """
+    Formats coordinate text for RADEC files with fixed-width sexagesimal components.
+
+    :param value: Coordinate value in sexagesimal string or decimal format
+    :param is_ra: True for RA (hours), False for Dec (degrees)
+    :param include_plus: Include '+' sign for positive Dec when True
+    :return: Normalized sexagesimal coordinate string
+    """
+    decimal_value = _to_decimal_coord(value)
+
+    sign = ""
+    if not is_ra:
+        if decimal_value < 0:
+            sign = "-"
+        elif include_plus:
+            sign = "+"
+
+    absolute_value = abs(decimal_value)
+    major = int(absolute_value)
+    minutes_float = (absolute_value - major) * 60.0
+    minutes = int(minutes_float)
+    seconds = round((minutes_float - minutes) * 60.0, 3)
+
+    if seconds >= 60.0:
+        seconds = 0.0
+        minutes += 1
+    if minutes >= 60:
+        minutes = 0
+        major += 1
+
+    return f"{sign}{major:02d}:{minutes:02d}:{seconds:06.3f}"
+
+
+# --- _to_decimal_coord ---
+# Converts coordinate input into decimal hours/degrees.
+def _to_decimal_coord(value):
+    """
+    Converts a coordinate value to decimal representation.
+
+    :param value: Coordinate value in sexagesimal string or decimal format
+    :return: Decimal coordinate value
+    """
+    if isinstance(value, str):
+        stripped = value.strip()
+        if ":" in stripped:
+            parts = stripped.split(":")
+            if len(parts) != 3:
+                raise ValueError(f"Invalid sexagesimal coordinate: {value}")
+
+            major = float(parts[0])
+            minutes = float(parts[1])
+            seconds = float(parts[2])
+
+            sign = -1.0 if major < 0 else 1.0
+            major_abs = abs(major)
+            decimal_value = major_abs + (minutes / 60.0) + (seconds / 3600.0)
+            return sign * decimal_value
+        return float(stripped)
+    return float(value)
 
 
 def _format_radec_magnitude(value):
@@ -475,7 +542,9 @@ def create_lines(ra_list, dec_list, mag_list, ra, dec, filt):
         angle = angle_dist(float(ra), float(dec), next_ra, next_dec)
         if angle:
             mag_text = _format_radec_magnitude(mag_list[count])
-            lines += str(val) + ", " + str(dec_list[count]) + ", " + "1, 1, " + mag_text + "\n"
+            ra_text = _format_sexagesimal_coord(val, is_ra=True)
+            dec_text = _format_sexagesimal_coord(dec_list[count], is_ra=False)
+            lines += ra_text + ", " + dec_text + ", " + "1, 1, " + mag_text + "\n"
 
     return lines
 

--- a/EclipsingBinaries/gaia.py
+++ b/EclipsingBinaries/gaia.py
@@ -2,7 +2,7 @@
 Author: Kyle Koeller
 Date Created: 03/08/2023
 
-Last Edited: 01/25/2026
+Last Edited: 04/19/2026
 This program queries Gaia DR3, to gather specific parameters
 
 https://gea.esac.esa.int/archive/
@@ -12,9 +12,15 @@ https://arxiv.org/pdf/2012.01916.pdf
 """
 
 from pyia import GaiaData
+from astroquery.vizier import Vizier
+from astropy.coordinates import SkyCoord
+import astropy.units as u
 import pandas as pd
-import math as mt
+import numpy as np
 import os
+from requests import exceptions as request_exceptions
+import socket
+import time
 
 from .vseq_updated import splitter
 
@@ -102,7 +108,236 @@ def target_star(ra_input, dec_input, output_path, write_callback=None, cancel_ev
         raise
 
 
-def tess_mag(ra, dec, write_callback, cancel_event):
+# --- _is_timeout_exception ---
+# Identifies network timeout errors that should trigger retries or fallback.
+def _is_timeout_exception(error: Exception) -> bool:
+    timeout_types = (
+        TimeoutError,
+        socket.timeout,
+        request_exceptions.Timeout,
+        request_exceptions.ReadTimeout,
+    )
+    if isinstance(error, timeout_types):
+        return True
+    return "timed out" in str(error).lower()
+
+
+# --- _empty_tic_dataframe ---
+# Creates a standardized empty TIC dataframe with expected columns.
+def _empty_tic_dataframe() -> pd.DataFrame:
+    return pd.DataFrame(columns=["_RAJ2000", "_DEJ2000", "Tmag", "e_Tmag"])
+
+
+# --- _compute_tmag_limit ---
+# Computes a TIC Tmag filter limit from APASS V magnitudes.
+def _compute_tmag_limit(apass_vmag) -> float | None:
+    if apass_vmag is None:
+        return None
+
+    v_series = pd.to_numeric(pd.Series(apass_vmag), errors="coerce").dropna()
+    if v_series.empty:
+        return None
+
+    return float(v_series.max() + 1.0)
+
+
+# --- _query_single_tic_region ---
+# Queries TIC v8.2 for one sky region with retries and mirror fallback.
+def _query_single_tic_region(
+    center_coord: SkyCoord,
+    radius: u.Quantity,
+    tmag_limit: float | None = None,
+    write_callback=None,
+    cancel_event=None
+) -> pd.DataFrame:
+    def log(message):
+        """Log messages to the GUI if callback provided, otherwise print"""
+        if write_callback:
+            write_callback(message)
+        else:
+            print(message)
+
+    required_columns = ["_RAJ2000", "_DEJ2000", "Tmag", "e_Tmag"]
+    vizier_servers = (
+        "vizier.cds.unistra.fr",
+        "vizier.cfa.harvard.edu",
+    )
+    timeout_seconds = 60
+    retries_per_server = 2
+
+    last_timeout_error = None
+
+    for server_name in vizier_servers:
+        for attempt in range(1, retries_per_server + 1):
+            if cancel_event and cancel_event.is_set():
+                log("Task canceled.")
+                return _empty_tic_dataframe()
+
+            try:
+                column_filters = {}
+                if tmag_limit is not None:
+                    column_filters["Tmag"] = f"<{tmag_limit:.2f}"
+
+                vizier = Vizier(columns=required_columns, row_limit=-1, column_filters=column_filters)
+                vizier.TIMEOUT = timeout_seconds
+                vizier.VIZIER_SERVER = server_name
+                result = vizier.query_region(center_coord, radius=radius, catalog="IV/39/tic82")
+
+                if len(result) == 0:
+                    return _empty_tic_dataframe()
+
+                tic_df = result[0].to_pandas()
+                for column_name in required_columns:
+                    if column_name not in tic_df.columns:
+                        tic_df[column_name] = np.nan
+                    tic_df[column_name] = pd.to_numeric(tic_df[column_name], errors="coerce")
+
+                return tic_df[required_columns]
+
+            except Exception as error:
+                if _is_timeout_exception(error):
+                    last_timeout_error = error
+                    log(
+                        f"TIC query timeout via {server_name} "
+                        f"(attempt {attempt}/{retries_per_server})."
+                    )
+                    if attempt < retries_per_server:
+                        time.sleep(1.0)
+                        continue
+                    break
+                raise
+
+    if last_timeout_error is not None:
+        raise request_exceptions.ReadTimeout(last_timeout_error)
+
+    return _empty_tic_dataframe()
+
+
+# --- _query_tic_catalog ---
+# Queries TIC v8.2 from VizieR for all input coordinates with fallback behavior.
+def _query_tic_catalog(
+    ra_hours: np.ndarray,
+    dec_degrees: np.ndarray,
+    tmag_limit: float | None = None,
+    write_callback=None,
+    cancel_event=None
+) -> pd.DataFrame:
+    def log(message):
+        """Log messages to the GUI if callback provided, otherwise print"""
+        if write_callback:
+            write_callback(message)
+        else:
+            print(message)
+
+    if cancel_event and cancel_event.is_set():
+        log("Task canceled.")
+        return _empty_tic_dataframe()
+
+    if ra_hours.size == 0:
+        return _empty_tic_dataframe()
+
+    input_coords = SkyCoord(ra=ra_hours * 15.0 * u.deg, dec=dec_degrees * u.deg, frame="icrs")
+    center_ra = np.median(input_coords.ra.deg)
+    center_dec = np.median(input_coords.dec.deg)
+    center_coord = SkyCoord(ra=center_ra * u.deg, dec=center_dec * u.deg, frame="icrs")
+    max_sep = input_coords.separation(center_coord).max()
+    search_radius = max(max_sep + 30.0 * u.arcsec, 10.0 * u.arcsec)
+
+    try:
+        return _query_single_tic_region(
+            center_coord,
+            search_radius,
+            tmag_limit=tmag_limit,
+            write_callback=write_callback,
+            cancel_event=cancel_event,
+        )
+    except Exception as error:
+        if not _is_timeout_exception(error):
+            raise
+
+        log("Bulk TIC query timed out. Falling back to per-star TIC queries.")
+        star_radius = 5.0 * u.arcsec
+        tic_frames = []
+        for count, coord in enumerate(input_coords):
+            if cancel_event and cancel_event.is_set():
+                log("Task canceled.")
+                return _empty_tic_dataframe()
+
+            try:
+                star_df = _query_single_tic_region(
+                    coord,
+                    star_radius,
+                    tmag_limit=tmag_limit,
+                    write_callback=write_callback,
+                    cancel_event=cancel_event,
+                )
+                if not star_df.empty:
+                    tic_frames.append(star_df)
+            except Exception as star_error:
+                if _is_timeout_exception(star_error):
+                    log(
+                        f"Skipping TIC lookup for source {count + 1}/{ra_hours.size} due to timeout."
+                    )
+                    continue
+                raise
+
+        if not tic_frames:
+            log("No TIC entries were retrieved after fallback queries.")
+            return _empty_tic_dataframe()
+
+        combined_df = pd.concat(tic_frames, ignore_index=True).drop_duplicates()
+        return combined_df[["_RAJ2000", "_DEJ2000", "Tmag", "e_Tmag"]]
+
+
+# --- _match_tic_magnitudes ---
+# Matches input stars to nearest TIC source and formats Tmag outputs.
+def _match_tic_magnitudes(
+    ra_hours: np.ndarray,
+    dec_degrees: np.ndarray,
+    tic_df: pd.DataFrame
+) -> tuple[list[float], list[float]]:
+    if ra_hours.size == 0:
+        return [], []
+
+    if tic_df.empty:
+        return [99.999] * ra_hours.size, [99.999] * ra_hours.size
+
+    input_coords = SkyCoord(ra=ra_hours * 15.0 * u.deg, dec=dec_degrees * u.deg, frame="icrs")
+    catalog_coords = SkyCoord(
+        ra=tic_df["_RAJ2000"].to_numpy() * u.deg,
+        dec=tic_df["_DEJ2000"].to_numpy() * u.deg,
+        frame="icrs",
+    )
+
+    nearest_indices, separations, _ = input_coords.match_to_catalog_sky(catalog_coords)
+    max_match_sep = 3.0 * u.arcsec
+
+    tmag_list = []
+    tmag_error_list = []
+    for idx, separation in zip(nearest_indices, separations):
+        if separation > max_match_sep:
+            tmag_list.append(99.999)
+            tmag_error_list.append(99.999)
+            continue
+
+        row = tic_df.iloc[int(idx)]
+        tmag = row["Tmag"]
+        tmag_err = row["e_Tmag"]
+
+        if pd.isna(tmag):
+            tmag_list.append(99.999)
+        else:
+            tmag_list.append(float(format(float(tmag), ".3f")))
+
+        if pd.isna(tmag_err):
+            tmag_error_list.append(99.999)
+        else:
+            tmag_error_list.append(float(format(float(tmag_err), ".3f")))
+
+    return tmag_list, tmag_error_list
+
+
+def tess_mag(ra, dec, write_callback, cancel_event, apass_vmag=None):
     """
     Calculates TESS magnitudes for comparison stars
 
@@ -110,6 +345,7 @@ def tess_mag(ra, dec, write_callback, cancel_event):
     :param dec: List of DEC's for comparison stars
     :param write_callback: Function to write log messages to the GUI
     :param cancel_event:
+    :param apass_vmag: APASS V magnitudes for dynamic TIC Tmag filtering
 
     :return: list of TESS magnitudes and errors
     """
@@ -120,77 +356,43 @@ def tess_mag(ra, dec, write_callback, cancel_event):
         else:
             print(message)
     try:
-        if cancel_event.is_set():
+        if cancel_event and cancel_event.is_set():
             log("Task canceled.")
             return
-        T_list = []
-        T_err_list = []
-        for count, val in enumerate(ra):
-            if cancel_event.is_set():
-                log("Task canceled.")
-                return
-            # the query searching for the magnitudes and fluxes
-            g = GaiaData.from_query("""
-                SELECT TOP 2000 gaia_source.source_id,gaia_source.ra,gaia_source.dec,
-                gaia_source.phot_g_mean_flux_over_error,gaia_source.phot_g_mean_mag,
-                gaia_source.phot_bp_mean_flux_over_error,gaia_source.phot_bp_mean_mag,
-                gaia_source.phot_rp_mean_flux_over_error,gaia_source.phot_rp_mean_mag
-                FROM gaiadr3.gaia_source 
-                WHERE 
-                CONTAINS(
-                    POINT('ICRS',gaiadr3.gaia_source.ra,gaiadr3.gaia_source.dec),
-                    CIRCLE('ICRS',{},{}, {})
-            )=1""".format(val*15, dec[count], 0.0008333333333333334))
-            # 0.0002777777777777778 is 1 arcsecond,
-            # 0.0005555555555555556 is 2 arcseconds,
-            # 0.0008333333333333334 is 3 arcseconds
-            # 0.001388888888888889 is 5 arcseconds
 
-            # 13:27:50.4728234064 75:39:45.384765984
-            # 00:28:27.9684836736 78:57:42.657327180
+        ra_hours = np.asarray(ra, dtype=float)
+        dec_degrees = np.asarray(dec, dtype=float)
 
-            """
-            Each mag and flux from Gaia's filters
-            Use .value at the end of each Gaia variable to get only the number and not the unit
-            The fluxes are coming in as arrays and not quantities, so the .value cannot be applied like for the magnitudes
-            """
-            G = g.phot_g_mean_mag[:4].value
-            G_flux = g.phot_g_mean_flux_over_error[:4]
-            BP = g.phot_bp_mean_mag[:4].value
-            BP_flux = g.phot_bp_mean_flux_over_error[:4]
-            RP = g.phot_rp_mean_mag[:4].value
-            RP_flux = g.phot_rp_mean_flux_over_error[:4]
+        if ra_hours.size != dec_degrees.size:
+            raise ValueError("RA and DEC list lengths must match.")
 
-            if len(BP) == 0 or len(RP) == 0:
-                # this equation is used if there are no BP or RP magnitudes
-                if len(G) == 0 or len(G_flux) == 0:
-                    T_list.append(99.999)
-                    T_err_list.append(99.999)
-                else:
-                    T = G - 0.403
-                    G_err = (2.5 / mt.log(10)) * (G_flux[0] ** -1)
-                    T_list.append(T[0])
-                    T_err_list.append(G_err)
-            else:
-                # calculate the TESS magnitude (T) and corresponding error (T_err)
-                T = G - 0.00522555 * (BP - RP) ** 3 + 0.0891337 * (BP - RP) ** 2 - 0.633923 * (BP - RP) + 0.0324473
-                T = T[0]
+        tmag_limit = _compute_tmag_limit(apass_vmag)
 
-                # error propagation formulae
-                G_err = (2.5 / mt.log(10)) * (G_flux[0] ** -1)
-                BP_err = (2.5 / mt.log(10)) * (BP_flux[0] ** -1)
-                RP_err = (2.5 / mt.log(10)) * (RP_flux[0] ** -1)
+        log("Starting the query for the Vizier catalog.")
+        if tmag_limit is not None:
+            log(f"Applying TIC Tmag filter: Tmag < {tmag_limit:.2f}")
 
-                Bp_Rp_err = mt.sqrt(BP_err ** 2 + RP_err ** 2)
-                T_err = mt.sqrt(G_err ** 2 + (Bp_Rp_err * 3) ** 2)
+        tic_df = _query_tic_catalog(
+            ra_hours,
+            dec_degrees,
+            tmag_limit=tmag_limit,
+            write_callback=write_callback,
+            cancel_event=cancel_event,
+        )
 
-                # append to respective lists with only 2 decimal places, instead of ~15
-                T_list.append(float(format(T, ".2f")))
-                T_err_list.append(float(format(T_err, ".3f")))
+        log("Finished querying the IV/39/tic82 Vizier Catalog.")
+        log("Processing data from the Vizier catalog.")
 
-        log("Finished Gaia search and calculation of TESS magnitudes.")
+        if cancel_event and cancel_event.is_set():
+            log("Task canceled.")
+            return
 
-        return T_list, T_err_list
+        t_list, t_err_list = _match_tic_magnitudes(ra_hours, dec_degrees, tic_df)
+
+        log("Finished cataloging the Vizier results.")
+        log("Finished TIC v8.2 search and extraction of TESS magnitudes.")
+
+        return t_list, t_err_list
     except Exception as e:
         log(f"An error occurred: {e}")
         raise

--- a/EclipsingBinaries/gaia.py
+++ b/EclipsingBinaries/gaia.py
@@ -138,7 +138,7 @@ def _compute_tmag_limit(apass_vmag) -> float | None:
     if v_series.empty:
         return None
 
-    return float(v_series.max() + 1.0)
+    return float(v_series.max() + 2.0)
 
 
 # --- _query_single_tic_region ---
@@ -176,7 +176,7 @@ def _query_single_tic_region(
             try:
                 column_filters = {}
                 if tmag_limit is not None:
-                    column_filters["Tmag"] = f"<{tmag_limit:.2f}"
+                    column_filters["Tmag"] = f"<{tmag_limit:.3f}"
 
                 vizier = Vizier(columns=required_columns, row_limit=-1, column_filters=column_filters)
                 vizier.TIMEOUT = timeout_seconds
@@ -370,7 +370,7 @@ def tess_mag(ra, dec, write_callback, cancel_event, apass_vmag=None):
 
         log("Starting the query for the Vizier catalog.")
         if tmag_limit is not None:
-            log(f"Applying TIC Tmag filter: Tmag < {tmag_limit:.2f}")
+            log(f"Applying TIC Tmag filter: Tmag < {tmag_limit:.3f}")
 
         tic_df = _query_tic_catalog(
             ra_hours,

--- a/EclipsingBinaries/gaia.py
+++ b/EclipsingBinaries/gaia.py
@@ -138,7 +138,7 @@ def _compute_tmag_limit(apass_vmag) -> float | None:
     if v_series.empty:
         return None
 
-    return float(v_series.max() + 2.0)
+    return float(v_series.max() + 1.0)
 
 
 # --- _query_single_tic_region ---


### PR DESCRIPTION
PR Description:

This PR fixes issue #457  by replacing Gaia-based per-star TESS magnitude derivation with direct TIC v8.2 (IV/39/tic82) lookups, while keeping existing APASS call flow and user-facing outputs compatible.

What changed:

Refactored gaia.py:tess_mag(...) to query VizieR TIC v8.2 for Tmag and e_Tmag instead of deriving T from Gaia fluxes.
Preserved call compatibility for existing APASS integration, while adding optional APASS V-mag context for filtering.

I found that the TESS input catalog had many more stars than APASS, so I used max(Vmag)+1.0 to filter the stars returned from the VizieR query. The added dynamic TIC magnitude filtering: Tmag < max(APASS Vmag) + 1 reduces payload size and improves timing and reliability.

Added retry/mirror/fallback handling for VizieR timeouts to avoid hard failures on transient network/server issues.

Updated logging to mirror APASS-style Vizier query progress messages and clarified that Tmag comes from TIC v8.2.

Improved photometric precision handling: I found in apass.py the magnitudes were using .2f format and I changed it to .3f format throughout. All magnitudes and RADEC seconds now consistently output at 3 decimal places SS.sss instead of SS.000. Rc computation/output also updated to preserve 3-decimal precision.

Standardized RADEC coordinate formatting for all _B, _V, _R, _T files:
RA: HH:MM:SS.sss
Dec: ±DD:MM:SS.sss (zero-padded components)

Preserved original target coordinate text precision/sign in RADEC headers where provided.

Why:

Addresses slow/fragile Gaia per-star behavior reported in issue 457.
Uses authoritative TIC TESS magnitudes directly.
Improves robustness against remote catalog timeouts.

Eliminates formatting/precision inconsistencies in generated RADEC products.

Outcome:

Much faster and more reliable Tmag population in APASS comparison-star workflow.
Better match fidelity for close TIC counterparts.
Consistent, AIJ-friendly RADEC formatting and precision across all filter files.

John