### PR TITLE
Fix RADEC file pickers and filter name matching for issue #465

### DIFF
--- a/EclipsingBinaries/menu.py
+++ b/EclipsingBinaries/menu.py
@@ -806,19 +806,19 @@ class ProgramLauncher(TkinterDnD.Tk):
                                                r"C:\folder1\B.radec", row=3,
                                                validation_func=lambda x: len(x.strip()) > 0,
                                                error_message="Please enter a file pathway with file name",
-                                               browse_type="folder")
+                                               browse_type="file")
 
         radec_v_file = self.create_input_field(self.right_frame, "RADEC File (V Filter):",
                                                r"C:\folder1\V.radec", row=4,
                                                validation_func=lambda x: len(x.strip()) > 0,
                                                error_message="Please enter a file pathway with file name.",
-                                               browse_type="folder")
+                                               browse_type="file")
 
         radec_r_file = self.create_input_field(self.right_frame, "RADEC File (R Filter):",
                                                r"C:\folder1\R.radec", row=5,
                                                validation_func=lambda x: len(x.strip()) > 0,
                                                error_message="Please enter a file pathway with file name.",
-                                               browse_type="folder")
+                                               browse_type="file")
 
         # Run button
         self.create_run_button(self.right_frame, self.run_multi_aperture_photometry, row=6,

--- a/EclipsingBinaries/multi_aperture_photometry.py
+++ b/EclipsingBinaries/multi_aperture_photometry.py
@@ -51,8 +51,13 @@ def main(path="", pipeline=False, radec_list=None, obj_name="", write_callback=N
     cancel_event : threading.Event
         Event flag that allows external cancellation of the running task.
     """
-    # Filters expected in the image collection, matched positionally with radec_list
-    filt_list = ["Empty/B", "Empty/V", "Empty/R"]
+    # Candidate filter names per band: "Empty/X" (BSUO/MaxIm native) tried first,
+    # plain "X" as fallback for images calibrated by other pipelines.
+    filt_candidates = [
+        ("Empty/B", "B"),
+        ("Empty/V", "V"),
+        ("Empty/R", "R"),
+    ]
 
     def log(message):
         if write_callback:
@@ -64,13 +69,20 @@ def main(path="", pipeline=False, radec_list=None, obj_name="", write_callback=N
         images_path = Path(path)
         files = ccdp.ImageFileCollection(images_path)
 
-        for filt, radec_file in zip(filt_list, radec_list):
+        for (filt_primary, filt_alt), radec_file in zip(filt_candidates, radec_list):
             # Respect cancellation between filters so the task exits cleanly
             if cancel_event and cancel_event.is_set():
                 log("Multi-Aperture Photometry was canceled.")
                 return
 
-            image_list = files.files_filtered(imagetyp='LIGHT', filter=filt)
+            image_list = list(files.files_filtered(imagetyp='LIGHT', filter=filt_primary))
+            filt = filt_primary
+            if not image_list:
+                alt_list = list(files.files_filtered(imagetyp='LIGHT', filter=filt_alt))
+                if alt_list:
+                    image_list = alt_list
+                    filt = filt_alt
+
             log(f"Processing {len(image_list)} images for {filt} filter.")
 
             multiple_AP(
@@ -400,8 +412,8 @@ def multiple_AP(image_list, path, filt, pipeline=False, obj_name="", radec_file=
         ax.legend(loc="upper right", fontsize=fontsize).set_draggable(True)
         ax.tick_params(axis='both', which='major', labelsize=fontsize)
 
-        filter_letter = filt.split("/")
-        plt.savefig(path / f"{obj_name}_{filter_letter[1]}_figure.jpg")
+        filter_letter = filt.split("/")[-1]
+        plt.savefig(path / f"{obj_name}_{filter_letter}_figure.jpg")
         plt.close()
 
         # ---------------------------------------------------------------------------
@@ -414,7 +426,7 @@ def multiple_AP(image_list, path, filt, pipeline=False, obj_name="", radec_file=
             'Source_AMag_T1_Error': mag_err
         })
 
-        output_file = path / f"{obj_name}_{filter_letter[1]}_data.csv"
+        output_file = path / f"{obj_name}_{filter_letter}_data.csv"
         light_curve_data.to_csv(output_file, index=False)
         log(f"Saved light curve data for {filt} to {output_file}")
 


### PR DESCRIPTION
- Change the three RADEC file inputs in the Multi-Aperture Photometry panel from folder pickers to file pickers (menu.py).
- Replace the hardcoded filt_list with per-band candidate pairs so that both "Empty/X" (BSUO/IRAF-reduced) and plain "X" (externally calibrated) FILTER header values are matched. "Empty/X" is tried first; plain "X" is the fallback when no images are found.
- Fix filt.split("/")[-1] so output file names are correct for both naming formats.

Note:  All tests pass but the new "B", "V", and "R" FILTER keywords are accepted but not tested.  Let me know if  you want me to update the test for this new feature.

John