### PR TITLE
Issue 467 flexible filter keyword

### DIFF
--- a/EclipsingBinaries/multi_aperture_photometry.py
+++ b/EclipsingBinaries/multi_aperture_photometry.py
@@ -3,7 +3,7 @@ Analyze images using aperture photometry within Python and not with Astro ImageJ
 
 Author: Kyle Koeller
 Created: 05/07/2023
-Last Updated: 04/19/2026
+Last Updated: 04/27/2026
 """
 
 # Python imports
@@ -30,6 +30,77 @@ warnings.filterwarnings("ignore", category=wcs.FITSFixedWarning)
 # Use non-interactive backend so plots can be saved without a display
 matplotlib.use('Agg')
 
+import json
+import os
+
+_config_loaded_attempted = False
+_loaded_config = None
+_config_path_used = None
+_config_log_printed = False
+
+def load_filter_config(radec_dir):
+    global _loaded_config, _config_path_used, _config_loaded_attempted
+    if _config_loaded_attempted:
+        return _loaded_config, _config_path_used
+    
+    _config_loaded_attempted = True
+    
+    paths_to_check = []
+    if radec_dir:
+        paths_to_check.append(Path(radec_dir) / "filter_config.json")
+    paths_to_check.append(Path.cwd() / "filter_config.json")
+    paths_to_check.append(Path.home() / ".EclipsingBinaries" / "filter_config.json")
+    
+    for p in paths_to_check:
+        if p.exists():
+            try:
+                with open(p, "r") as f:
+                    _loaded_config = json.load(f)
+                _config_path_used = str(p)
+                return _loaded_config, _config_path_used
+            except Exception:
+                pass
+    return None, None
+
+def resolve_filter(header, radec_dir=None, log=print):
+    global _config_log_printed
+    filt_candidates = {
+        "Empty/B": "B", "B": "B",
+        "Empty/V": "V", "V": "V",
+        "Empty/R": "R", "R": "R",
+    }
+    
+    filter_val = None
+    if "FILTER" in header:
+        filter_val = header["FILTER"]
+    elif "FILTERS" in header:
+        filter_val = header["FILTERS"]
+        
+    if filter_val in filt_candidates:
+        return filt_candidates[filter_val]
+        
+    config, config_path = load_filter_config(radec_dir)
+    if not config:
+        return filter_val
+        
+    if not _config_log_printed:
+        log(f"Using filter configuration from {config_path}")
+        _config_log_printed = True
+        
+    for telescope in config.get("TELESCOPE", []):
+        ident = telescope.get("identification", {})
+        fits_key = ident.get("fits_key")
+        match_value = ident.get("match_value")
+        
+        if fits_key in header and header[fits_key] == match_value:
+            for filt in telescope.get("filters", []):
+                f_key = filt.get("fits_key")
+                f_match = filt.get("match_value")
+                
+                if f_key in header and header[f_key] == f_match:
+                    return filt.get("processing_symbol")
+                    
+    return filter_val
 
 def main(path="", pipeline=False, radec_list=None, obj_name="", write_callback=None, cancel_event=None):
     """
@@ -51,13 +122,10 @@ def main(path="", pipeline=False, radec_list=None, obj_name="", write_callback=N
     cancel_event : threading.Event
         Event flag that allows external cancellation of the running task.
     """
-    # Candidate filter names per band: "Empty/X" (BSUO/MaxIm native) tried first,
-    # plain "X" as fallback for images calibrated by other pipelines.
-    filt_candidates = [
-        ("Empty/B", "B"),
-        ("Empty/V", "V"),
-        ("Empty/R", "R"),
-    ]
+    global _config_loaded_attempted, _config_log_printed, _loaded_config
+    _config_loaded_attempted = False
+    _config_log_printed = False
+    _loaded_config = None
 
     def log(message):
         if write_callback:
@@ -68,27 +136,40 @@ def main(path="", pipeline=False, radec_list=None, obj_name="", write_callback=N
     try:
         images_path = Path(path)
         files = ccdp.ImageFileCollection(images_path)
+        
+        valid_radec = [r for r in radec_list if r and Path(r).exists()] if radec_list else []
+        radec_dir = Path(valid_radec[0]).parent if valid_radec else None
 
-        for (filt_primary, filt_alt), radec_file in zip(filt_candidates, radec_list):
-            # Respect cancellation between filters so the task exits cleanly
+        # Group LIGHT images by resolved filter symbol
+        grouped_images = {}
+        for header, file_name in files.headers(imagetyp='LIGHT', return_fname=True):
+            sym = resolve_filter(header, radec_dir=radec_dir, log=log)
+            if sym is not None:
+                grouped_images.setdefault(sym, []).append(file_name)
+                
+        # To maintain compatibility with existing radec_list order (B, V, R)
+        expected_symbols = ["B", "V", "R"]
+        
+        for idx, sym in enumerate(expected_symbols):
             if cancel_event and cancel_event.is_set():
                 log("Multi-Aperture Photometry was canceled.")
                 return
-
-            image_list = list(files.files_filtered(imagetyp='LIGHT', filter=filt_primary))
-            filt = filt_primary
+                
+            if radec_list and idx < len(radec_list):
+                radec_file = radec_list[idx]
+            else:
+                continue
+                
+            image_list = grouped_images.get(sym, [])
             if not image_list:
-                alt_list = list(files.files_filtered(imagetyp='LIGHT', filter=filt_alt))
-                if alt_list:
-                    image_list = alt_list
-                    filt = filt_alt
+                continue
 
-            log(f"Processing {len(image_list)} images for {filt} filter.")
+            log(f"Processing {len(image_list)} images for {sym} filter.")
 
             multiple_AP(
                 image_list=image_list,
                 path=images_path,
-                filt=filt,
+                filt=sym,
                 pipeline=pipeline,
                 obj_name=obj_name,
                 radec_file=radec_file,
@@ -98,6 +179,7 @@ def main(path="", pipeline=False, radec_list=None, obj_name="", write_callback=N
 
     except Exception as e:
         log(f"An error occurred in Multi-Aperture Photometry: {e}")
+        raise
 
 
 def multiple_AP(image_list, path, filt, pipeline=False, obj_name="", radec_file="",

--- a/EclipsingBinaries/multi_aperture_photometry.py
+++ b/EclipsingBinaries/multi_aperture_photometry.py
@@ -31,7 +31,7 @@ warnings.filterwarnings("ignore", category=wcs.FITSFixedWarning)
 matplotlib.use('Agg')
 
 import json
-import os
+
 
 _config_loaded_attempted = False
 _loaded_config = None
@@ -58,8 +58,8 @@ def load_filter_config(radec_dir):
                     _loaded_config = json.load(f)
                 _config_path_used = str(p)
                 return _loaded_config, _config_path_used
-            except Exception:
-                pass
+            except (FileNotFoundError, json.JSONDecodeError, OSError):
+                continue
     return None, None
 
 def resolve_filter(header, radec_dir=None, log=print):

--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -137,3 +137,50 @@ For a negative declination::
     Do not use the same folder for both ``INPUT_DIR`` and ``OUTPUT_DIR``. The reduction
     stage writes files to ``OUTPUT_DIR`` and monitoring ``INPUT_DIR`` for new files could
     behave unexpectedly if they overlap.
+
+Custom Filter Mapping
+---------------------
+
+If your telescope uses a filter naming convention different from the default ``Empty/B``, ``Empty/V``, or ``Empty/R`` in its FITS headers, you can provide a ``filter_config.json`` file to map them to the standard processing symbols (``B``, ``V``, ``R``). 
+
+.. note::
+    It is **not** necessary to add this configuration file if your images already conform to the default ``Empty/B`` or ``B`` naming convention (as well as ``V`` and ``R``). The script will automatically process standard filter names.
+
+If you do need custom mapping, the script will search for ``filter_config.json`` in the following order:
+
+1. The directory containing your ``.radec`` files
+2. Your current working directory
+3. Your home directory (e.g., ``~/.EclipsingBinaries/filter_config.json`` on Mac/Linux or ``C:\Users\<username>\.EclipsingBinaries\filter_config.json`` on Windows)
+
+**Example Configuration:**
+
+.. code-block:: json
+
+    {
+      "TELESCOPE": [
+        {
+          "name": "BSUO",
+          "identification": {
+            "fits_key": "OBSERVAT",
+            "match_value": "BSUO"
+          },
+          "filters": [
+            {
+              "name": "Johnson B",
+              "fits_key": "FILTER",
+              "match_value": "Custom_B",
+              "processing_symbol": "B"
+            },
+            {
+              "name": "Johnson V",
+              "fits_key": "FILTER",
+              "match_value": "Custom_V",
+              "processing_symbol": "V"
+            }
+          ]
+        }
+      ]
+    }
+
+.. warning::
+    When the Astropy library reads string values from a FITS header, it automatically strips all trailing spaces. If your FITS file has ``OBSERVAT= 'SFRO    '``, your ``match_value`` in the JSON file must be exactly ``"SFRO"`` without the spaces.

--- a/tests/test_multi_aperture_photometry.py
+++ b/tests/test_multi_aperture_photometry.py
@@ -331,7 +331,7 @@ def test_main_processes_each_filter():
 
 def test_main_passes_correct_filter_to_multiple_ap():
     from EclipsingBinaries.multi_aperture_photometry import main
-    from unittest.mock import MagicMock, patch, call
+    from unittest.mock import MagicMock, patch
 
     cancel = MagicMock()
     cancel.is_set.return_value = False

--- a/tests/test_multi_aperture_photometry.py
+++ b/tests/test_multi_aperture_photometry.py
@@ -291,14 +291,16 @@ def test_main_cancels_before_processing():
 def test_main_logs_error_on_bad_path():
     from EclipsingBinaries.multi_aperture_photometry import main
     from unittest.mock import MagicMock
+    import pytest
 
     cancel = MagicMock()
     cancel.is_set.return_value = False
     messages = []
 
-    main(path="/nonexistent/path/xyz", pipeline=True,
-         radec_list=["a.radec", "b.radec", "c.radec"],
-         obj_name="test", write_callback=messages.append, cancel_event=cancel)
+    with pytest.raises(Exception):
+        main(path="/nonexistent/path/xyz", pipeline=True,
+             radec_list=["a.radec", "b.radec", "c.radec"],
+             obj_name="test", write_callback=messages.append, cancel_event=cancel)
 
     assert any("error" in m.lower() for m in messages)
 
@@ -312,7 +314,10 @@ def test_main_processes_each_filter():
     messages = []
 
     mock_collection = MagicMock()
-    mock_collection.files_filtered.return_value = []
+    h1 = {"FILTER": "B"}
+    h2 = {"FILTER": "V"}
+    h3 = {"FILTER": "R"}
+    mock_collection.headers.return_value = [(h1, "img1.fits"), (h2, "img2.fits"), (h3, "img3.fits")]
 
     with patch("EclipsingBinaries.multi_aperture_photometry.ccdp.ImageFileCollection",
                return_value=mock_collection), \
@@ -332,7 +337,10 @@ def test_main_passes_correct_filter_to_multiple_ap():
     cancel.is_set.return_value = False
 
     mock_collection = MagicMock()
-    mock_collection.files_filtered.return_value = []
+    h1 = {"FILTER": "B"}
+    h2 = {"FILTER": "V"}
+    h3 = {"FILTER": "R"}
+    mock_collection.headers.return_value = [(h1, "img1.fits"), (h2, "img2.fits"), (h3, "img3.fits")]
 
     with patch("EclipsingBinaries.multi_aperture_photometry.ccdp.ImageFileCollection",
                return_value=mock_collection), \
@@ -342,9 +350,9 @@ def test_main_passes_correct_filter_to_multiple_ap():
              obj_name="test", write_callback=None, cancel_event=cancel)
 
     filters_used = [c.kwargs["filt"] for c in mock_ap.call_args_list]
-    assert "Empty/B" in filters_used
-    assert "Empty/V" in filters_used
-    assert "Empty/R" in filters_used
+    assert "B" in filters_used
+    assert "V" in filters_used
+    assert "R" in filters_used
 
 
 # ===========================================================================


### PR DESCRIPTION
### **Description**
This PR resolves #467 by implementing a flexible configuration system to map custom observatory filter keywords to standard processing symbols (B, V, R), while maintaining full backward compatibility with default filter names.

### Key Changes
Flexible Filter Mapping:
Added support for an **optional** filter_config.json file.
The script searches for this config file in: 
 - (1) the .radec directory, 
 - (2) the Current Working Directory, and 
 - (3) the user's home directory (~/.EclipsingBinaries/ or C:\Users\<user>\.EclipsingBinaries\).
Added a caching system so the GUI does not repeatedly re-read the configuration file during the same run, but safely resets between fresh pipeline runs.

### Documentation:
Updated docs/pipeline.rst with a new Custom Filter Mapping section detailing the filter_config.json file format, search locations, and a warning regarding Astropy's default whitespace-stripping behavior.

### Testing:
Refactored tests/test_multi_aperture_photometry.py to mock headers() instead of ccds().
Updated the bad path test case to use pytest.raises(Exception) to account for the error propagation.
All 42 tests are passing.

### Closes
Closes #467